### PR TITLE
NOREF: Setting up fake worker fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,8 @@
                 "webpack": "^5.11.1",
                 "webpack-cli": "^4.3.1",
                 "webpack-dev-server": "^4.11.1",
-                "webpack-merge": "^5.8.0"
+                "webpack-merge": "^5.8.0",
+                "worker-loader": "^3.0.8"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -4301,6 +4302,15 @@
                 "url": "https://github.com/Pomax/bezierjs/blob/master/FUNDING.md"
             }
         },
+        "node_modules/big.js": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+            "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+            "dev": true,
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/binary-extensions": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -5852,6 +5862,15 @@
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "dev": true
+        },
+        "node_modules/emojis-list": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+            "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+            "dev": true,
+            "engines": {
+                "node": ">= 4"
+            }
         },
         "node_modules/encodeurl": {
             "version": "1.0.2",
@@ -8653,6 +8672,20 @@
             "dev": true,
             "engines": {
                 "node": ">=6.11.5"
+            }
+        },
+        "node_modules/loader-utils": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+            "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+            "dev": true,
+            "dependencies": {
+                "big.js": "^5.2.2",
+                "emojis-list": "^3.0.0",
+                "json5": "^2.1.2"
+            },
+            "engines": {
+                "node": ">=8.9.0"
             }
         },
         "node_modules/locate-path": {
@@ -12233,6 +12266,26 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/worker-loader": {
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/worker-loader/-/worker-loader-3.0.8.tgz",
+            "integrity": "sha512-XQyQkIFeRVC7f7uRhFdNMe/iJOdO6zxAaR3EWbDp45v3mDhrTi+++oswKNxShUNjPC/1xUp5DB29YKLhFo129g==",
+            "dev": true,
+            "dependencies": {
+                "loader-utils": "^2.0.0",
+                "schema-utils": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependencies": {
+                "webpack": "^4.0.0 || ^5.0.0"
             }
         },
         "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
         "webpack": "^5.11.1",
         "webpack-cli": "^4.3.1",
         "webpack-dev-server": "^4.11.1",
-        "webpack-merge": "^5.8.0"
+        "webpack-merge": "^5.8.0",
+        "worker-loader": "^3.0.8"
     },
     "private": true,
     "dependencies": {

--- a/src/components/PdfReaderComponent.js
+++ b/src/components/PdfReaderComponent.js
@@ -13,7 +13,7 @@ import { PdfPageComponent } from "./PdfPageComponent";
 import { respondToVisibility } from "../services/Utils";
 import { EXTRA_PAGES_TO_RENDER } from "../Constants";
 
-const pdfjsLib = require("pdfjs-dist");
+import * as pdfjsLib from "pdfjs-dist/webpack";
 
 /**
  * Component representing the PDF reader. Displays the content of PDF document and actions
@@ -102,7 +102,6 @@ class PdfReaderComponent {
    */
   loadPdf = (pdf) => {
     const self = this;
-    pdfjsLib.GlobalWorkerOptions.workerSrc = "/pdf.worker.bundle.js";
     pdfjsLib
       .getDocument(pdf)
       .promise.then((data) => {

--- a/src/services/DocumentParser/ImageExtractorService.js
+++ b/src/services/DocumentParser/ImageExtractorService.js
@@ -1,6 +1,6 @@
 import { DocumentParser } from "./DocumentParser";
 
-const pdfjsLib = require("pdfjs-dist");
+import * as pdfjsLib from "pdfjs-dist/webpack";
 
 /**
  * @extends DocumentParser

--- a/src/services/TextRenderService.js
+++ b/src/services/TextRenderService.js
@@ -3,7 +3,7 @@ import { EventHandlerService, PDFLEvents } from "./EventHandlerService";
  * Declaration of library that contains the method to render text and annotations
  * @constant
  */
-const pdfjsLib = require("pdfjs-dist");
+import * as pdfjsLib from "pdfjs-dist/webpack";
 const pdfjsViewer = require("pdfjs-dist/web/pdf_viewer");
 
 /**

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -6,9 +6,8 @@ const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 /**
  * Config file for webpack bundling.
  * Configures how and where webpack will build the source code:
- *  - produces 2 js bundles:
+ *  - produces 1 js bundle:
  *    - main: where our own source js code is
- *    - pdf.worker: pdf.js worker needed by pdf.js library
  *  - for html files it just copies them with the correct refrences
  *  - for css we use 'mini-css-extract-plugin' which will for production
  *      build optimzed separate css file and for develpment use a 'css-loader'
@@ -18,7 +17,6 @@ module.exports = {
   context: __dirname,
   entry: {
     main: "./src/main.js",
-    "pdf.worker": "pdfjs-dist/build/pdf.worker.entry",
   },
   output: {
     path: path.join(__dirname, "/dist"),


### PR DESCRIPTION
Pdf.js is now imported from pdfjs-dist/webpack which is the reccomended way for working with webpack.
This resolves the issue.